### PR TITLE
Fix store code not being added to product links

### DIFF
--- a/src/module-elasticsuite-autocomplete/Model/Render/Category.php
+++ b/src/module-elasticsuite-autocomplete/Model/Render/Category.php
@@ -100,6 +100,6 @@ class Category
             $requestPath = $this->getFirstResult($categoryData['_source']['url_key']) . $suffix;
         }
 
-        return $this->storeManager->getStore()->getBaseUrl(UrlInterface::URL_TYPE_WEB) . $this->getFirstResult($requestPath);
+        return $this->storeManager->getStore()->getBaseUrl(UrlInterface::URL_TYPE_LINK) . $this->getFirstResult($requestPath);
     }
 }

--- a/src/module-elasticsuite-autocomplete/Model/Render/Product.php
+++ b/src/module-elasticsuite-autocomplete/Model/Render/Product.php
@@ -216,10 +216,10 @@ class Product
             $requestPath =  $this->getFirstResult($productData['_source']['request_path']);
         } else {
             $suffix = (string)$this->scopeConfig->getValue(ProductUrlPathGenerator::XML_PATH_PRODUCT_URL_SUFFIX, ScopeInterface::SCOPE_STORE);
-            $requestPath = $this->getFirstResult($productData['_source']['url_key']) .".html";
+            $requestPath = $this->getFirstResult($productData['_source']['url_key']) . $suffix;
         }
 
-        return $this->storeManager->getStore()->getBaseUrl(UrlInterface::URL_TYPE_WEB) . $requestPath;
+        return $this->storeManager->getStore()->getBaseUrl(UrlInterface::URL_TYPE_LINK) . $requestPath;
     }
 
     /**


### PR DESCRIPTION
Hi,

This fixes issue #3

Basically, when using a multi store configuration with store codes added to urls, the store code was not being added to the product url (and we got 404 pages when clicking on quick search results).

I've also set the $suffix (all the code was there, but it was not set) in the product render.