### PR TITLE
Fixed issue when reindexing just one category

### DIFF
--- a/src/module-elasticsuite-autocomplete/Model/Indexer/Category/Fulltext/Datasource/Url.php
+++ b/src/module-elasticsuite-autocomplete/Model/Indexer/Category/Fulltext/Datasource/Url.php
@@ -46,7 +46,9 @@ class Url implements DatasourceInterface
         $requestPathData = $this->getRequestPathData((int)$storeId);
         /** @var string[] $data */
         foreach ($requestPathData as $data) {
-            $indexData[(int)$data['entity_id']]['request_path'] = $data['request_path'];
+            if (isset($indexData[(int)$data['entity_id']])) {
+                $indexData[(int)$data['entity_id']]['request_path'] = $data['request_path'];
+            }
         }
 
         return $indexData;


### PR DESCRIPTION
Hi,

In the current implementation, when you reindex one category (you save it for example), the following happens:

- The category that's been saved is indexed correctly with all attributes;
- All other categories are indexed, but with only one attribute: request_path.

This happens because the "getRequestPathData" function just gets all categories from the URL rewrite table and is then used as basis to add into $indexData. Thus creating a lot of 'empty' categories.

This is a relatively quick fix for this problem. Perhaps a more elegant fix would be adding a `$categoryIds` param to the `getRequestPathData` function in order to - optionally - just get the `$categoryIds` needed instead of all categories.

BTW: Great module!