### PR TITLE
Fixed bug when working with a table prefix the table cannot been found

### DIFF
--- a/src/module-elasticsuite-autocomplete/Model/Indexer/Category/Fulltext/Datasource/Url.php
+++ b/src/module-elasticsuite-autocomplete/Model/Indexer/Category/Fulltext/Datasource/Url.php
@@ -65,7 +65,7 @@ class Url implements DatasourceInterface
     {
         $connection = $this->resource->getConnection();
         $select     = $connection->select()->from(
-            ['url_rewrite' => $connection->getTableName('url_rewrite')],
+            ['url_rewrite' => $this->resource->getTableName('url_rewrite')],
             ['request_path', 'entity_id']
         )->where('entity_type = ?', 'category')
             ->where('store_id = ?', $storeId)

--- a/src/module-elasticsuite-autocomplete/Model/Indexer/Product/Fulltext/Datasource/AdditionalAttributes.php
+++ b/src/module-elasticsuite-autocomplete/Model/Indexer/Product/Fulltext/Datasource/AdditionalAttributes.php
@@ -137,7 +137,7 @@ class AdditionalAttributes implements DatasourceInterface
         }
 
         $connection = $this->resource->getConnection();
-        $tableName  = $connection->getTableName('catalog_product_entity_' . $attribute->getBackendType());
+        $tableName  = $this->resource->getTableName('catalog_product_entity_' . $attribute->getBackendType());
         $select     = $connection->select()->from(
             ['cpe_default' => $tableName],
             []

--- a/src/module-elasticsuite-autocomplete/Model/Indexer/Product/Fulltext/Datasource/ConfigurablePrice.php
+++ b/src/module-elasticsuite-autocomplete/Model/Indexer/Product/Fulltext/Datasource/ConfigurablePrice.php
@@ -132,18 +132,18 @@ class ConfigurablePrice extends Indexer implements DatasourceInterface
     {
         $connection = $this->resource->getConnection();
         $select     = $connection->select()->from(
-            ['parent' => $connection->getTableName('catalog_product_entity')],
+            ['parent' => $this->resource->getTableName('catalog_product_entity')],
             []
         )->join(
-            ['link' => $connection->getTableName('catalog_product_relation')],
+            ['link' => $this->resource->getTableName('catalog_product_relation')],
             'link.parent_id = parent.entity_id',
             []
         )->join(
-            ['t' => $connection->getTableName($this->getPriceIndexDimensionsTables($websiteId))],
+            ['t' => $this->resource->getTableName($this->getPriceIndexDimensionsTables($websiteId))],
             't.entity_id = link.child_id ',
             []
         )->join(
-            ['csi' => $connection->getTableName('cataloginventory_stock_item')],
+            ['csi' => $this->resource->getTableName('cataloginventory_stock_item')],
             'csi.product_id = link.child_id AND csi.is_in_stock=' . $inStock ? '1' : '0',
             []
         )->columns([

--- a/src/module-elasticsuite-autocomplete/Model/Indexer/Product/Fulltext/Datasource/Url.php
+++ b/src/module-elasticsuite-autocomplete/Model/Indexer/Product/Fulltext/Datasource/Url.php
@@ -64,7 +64,7 @@ class Url implements DatasourceInterface
     {
         $connection = $this->resource->getConnection();
         $select     = $connection->select()->from(
-            ['url_rewrite' => $connection->getTableName('url_rewrite')],
+            ['url_rewrite' => $this->resource->getTableName('url_rewrite')],
             ['request_path', 'entity_id']
         )->where('entity_type = ?', 'product')
             ->where('entity_id IN (?)', $productId)


### PR DESCRIPTION
When using the connection->getTableName a prefix that is set in env.php is not taken into account.

When using the resource->getTableName this is the case.

So this MR fixes this problem with all getTableName functions