### PR TITLE
Fix ternary statement (fixes #11)

### DIFF
--- a/src/module-elasticsuite-autocomplete/Model/Indexer/Product/Fulltext/Datasource/ConfigurablePrice.php
+++ b/src/module-elasticsuite-autocomplete/Model/Indexer/Product/Fulltext/Datasource/ConfigurablePrice.php
@@ -144,7 +144,7 @@ class ConfigurablePrice extends Indexer implements DatasourceInterface
             []
         )->join(
             ['csi' => $connection->getTableName('cataloginventory_stock_item')],
-            'csi.product_id = link.child_id AND csi.is_in_stock=' . $inStock ? '1' : '0',
+            'csi.product_id = link.child_id AND csi.is_in_stock=' . ($inStock ? '1' : '0'),
             []
         )->columns([
             new \Zend_Db_Expr('t.customer_group_id'),


### PR DESCRIPTION
#11 reports an indexing performance regression due to a bad ternary statement in ConfigurablePrice. This fixes it.