### PR TITLE
Fix category path URLs

### DIFF
--- a/src/module-elasticsuite-autocomplete/Model/Render/Category.php
+++ b/src/module-elasticsuite-autocomplete/Model/Render/Category.php
@@ -97,7 +97,7 @@ class Category
             $requestPath =  $this->getFirstResult($categoryData['_source']['request_path']);
         } else {
             $suffix = (string)$this->scopeConfig->getValue(CategoryUrlPathGenerator::XML_PATH_CATEGORY_URL_SUFFIX, ScopeInterface::SCOPE_STORE);
-            $requestPath = $this->getFirstResult($categoryData['_source']['url_key']) . $suffix;
+            $requestPath = $this->getFirstResult($categoryData['_source']['url_path']) . $suffix;
         }
 
         return $this->storeManager->getStore()->getBaseUrl(UrlInterface::URL_TYPE_LINK) . $this->getFirstResult($requestPath);


### PR DESCRIPTION
# Problem

Nested category path URLs aren't output correctly (on current version of Magento + ElasticSuite).

```json
                "url_key": [
                    "pump-accessories"
                ],
                "url_path": [
                    "buckets\/tools\/pumps\/pump-accessories"
                ],
```

# Solution

This changes the code to output url_path rather than url_key (which is not a complete valid URL for any child categories).